### PR TITLE
feat: upgrade to Astro v6 beta + Cloudflare deploy config

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,20 +3,10 @@ import react from "@astrojs/react";
 import sitemap from "@astrojs/sitemap";
 import tailwindcss from "@tailwindcss/vite";
 import AutoImport from "astro-auto-import";
-import { defineConfig } from "astro/config";
+import { defineConfig, sharpImageService } from "astro/config";
 import remarkCollapse from "remark-collapse";
 import remarkToc from "remark-toc";
-import sharp from "sharp";
 import config from "./src/config/config.json";
-
-let highlighter;
-async function getHighlighter() {
-  if (!highlighter) {
-    const { getHighlighter } = await import("shiki");
-    highlighter = await getHighlighter({ theme: "one-dark-pro" });
-  }
-  return highlighter;
-}
 
 // https://astro.build/config
 export default defineConfig({
@@ -25,7 +15,7 @@ export default defineConfig({
   trailingSlash: config.site.trailing_slash ? "always" : "never",
 
   vite: { plugins: [tailwindcss()] },
-  image: { service: sharp() },
+  image: { service: sharpImageService() },
 
   integrations: [
     react(),
@@ -58,8 +48,6 @@ export default defineConfig({
       theme: "one-dark-pro",
       wrap: true,
     },
-    highlighter: getHighlighter,
 
-    extendDefaultPlugins: true,
   },
 });

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "preview": "astro preview",
     "format": "prettier -w ./src",
     "deploy:cf-workers": "npm run build && wrangler deploy",
-    "preview:cf-workers": "npm run build && wrangler dev"
+    "preview:cf-workers": "npm run build && wrangler dev",
+    "check": "astro check"
   },
   "dependencies": {
     "@astrojs/mdx": "5.0.0-beta.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hydrogen-astro",
-  "version": "6.0.0",
+  "version": "3.0.0",
   "description": "Astro and Tailwindcss Personal Blog Starter",
   "author": "statichunt",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "prettier-plugin-tailwindcss": "^0.6.11",
     "sharp": "0.33.5",
     "tailwindcss": "^4.1.4",
-    "typescript": "5.8.3",
-    "wrangler": "^4"
+    "typescript": "^5.0.0",
+    "wrangler": "^4",
+    "@astrojs/check": "0.9.7-beta.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hydrogen-astro",
-  "version": "2.5.0",
+  "version": "6.0.0",
   "description": "Astro and Tailwindcss Personal Blog Starter",
   "author": "statichunt",
   "license": "MIT",
@@ -9,14 +9,16 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "format": "prettier -w ./src"
+    "format": "prettier -w ./src",
+    "deploy:cf-workers": "npm run build && wrangler deploy",
+    "preview:cf-workers": "npm run build && wrangler dev"
   },
   "dependencies": {
-    "@astrojs/mdx": "4.2.5",
-    "@astrojs/react": "4.2.5",
+    "@astrojs/mdx": "5.0.0-beta.9",
+    "@astrojs/react": "5.0.0-beta.3",
     "@astrojs/rss": "4.0.11",
-    "@astrojs/sitemap": "3.3.1",
-    "astro": "5.7.5",
+    "@astrojs/sitemap": "3.6.1-beta.3",
+    "astro": "6.0.0-beta.17",
     "astro-auto-import": "^0.4.4",
     "astro-font": "^1.1.0",
     "date-fns": "^4.1.0",
@@ -33,7 +35,7 @@
     "remark-toc": "^9.0.0",
     "shiki": "^3.3.0",
     "swiper": "^11.2.6",
-    "vite": "^6.3.2"
+    "vite": "^7.3.1"
   },
   "devDependencies": {
     "@tailwindcss/forms": "^0.5.10",
@@ -48,6 +50,7 @@
     "prettier-plugin-tailwindcss": "^0.6.11",
     "sharp": "0.33.5",
     "tailwindcss": "^4.1.4",
-    "typescript": "5.8.3"
+    "typescript": "5.8.3",
+    "wrangler": "^4"
   }
 }

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,5 +1,6 @@
 import { glob } from "astro/loaders";
-import { defineCollection, z } from "astro:content";
+import { defineCollection } from "astro:content";
+import { z } from "astro/zod";
 
 // Post collection schema
 const postCollection = defineCollection({
@@ -8,11 +9,11 @@ const postCollection = defineCollection({
     title: z.string(),
     meta_title: z.string().optional(),
     description: z.string().optional(),
-    date: z.date().optional(),
+    date: z.coerce.date().optional(),
     image: z.string().optional(),
     author: z.string().default("Admin"),
-    categories: z.array(z.string()).default(["others"]),
-    tags: z.array(z.string()).default(["others"]),
+    categories: z.array(z.string()).default(() => ["others"]),
+    tags: z.array(z.string()).default(() => ["others"]),
     draft: z.boolean().optional(),
   }),
 });

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -13,7 +13,7 @@ const { pathname } = Astro.url;
 // font families
 const pf = theme.fonts.font_family.primary;
 
-let fontPrimary, fontSecondary;
+let fontPrimary;
 if (theme.fonts.font_family.primary) {
   fontPrimary = theme.fonts.font_family.primary
     .replace(/\+/g, " ")

--- a/src/layouts/components/Post.astro
+++ b/src/layouts/components/Post.astro
@@ -2,7 +2,7 @@
 import dateFormat from "@/lib/utils/dateFormat";
 
 const { post, className } = Astro.props;
-const { id, slug, body, data, collection } = post;
+const { id, data } = post;
 ---
 
 <div class={className}>

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,11 @@
+{
+  // Cloudflare Workers — Static Assets deployment
+  // Deploy:  npm run deploy:cf-workers
+  // Preview: npm run preview:cf-workers
+  "name": "hydrogen-astro",
+  "compatibility_date": "2026-03-01",
+  "assets": {
+    "directory": "./dist",
+    "not_found_handling": "404-page"
+  }
+}


### PR DESCRIPTION
Upgrades to Astro v6 beta (6.0.0-beta.17) + Cloudflare deploy config. Build: 0 errors. See branch feat/astro-v6-cloudflare.